### PR TITLE
Fix docs for environment variables

### DIFF
--- a/SLACK_SETUP.md
+++ b/SLACK_SETUP.md
@@ -52,15 +52,15 @@ In your GitHub repository, go to **Settings** → **Security** → **Secrets and
 Add the following repository variables:
 
 ### Required for Slack Integration:
-- `SLACK_CHANNEL_ENABLED` = `true`
-- `SLACK_TOKEN` = `xoxb-your-bot-token-here`
-- `SLACK_CHANNEL_ID` = `C1234567890` (your channel ID)
+- `ROASTER_SLACK_CHANNEL_ENABLED` = `true`
+- `ROASTER_SLACK_TOKEN` = `xoxb-your-bot-token-here`
+- `ROASTER_SLACK_CHANNEL_ID` = `C1234567890` (your channel ID)
 
 ### Optional GitHub Channel Control:
-- `GITHUB_CHANNEL_ENABLED` = `true` (default: true)
+- `ROASTER_GITHUB_CHANNEL_ENABLED` = `true` (default: true)
 
-### Other Configuration:
-- `OPENAI_API_KEY` = `sk-your-openai-api-key` (required)
+-### Other Configuration:
+- `ROASTER_OPENAI_API_KEY` = `sk-your-openai-api-key` (required)
 - `ROASTER_UNCENSORED` = `false` (default: false)
 
 ## Step 6: Test Your Setup
@@ -84,12 +84,12 @@ You can configure which channels are enabled:
 
 ### Common Issues:
 
-1. **"Missing SLACK_TOKEN"**
-   - Ensure you've set the `SLACK_TOKEN` repository variable
+1. **"Missing ROASTER_SLACK_TOKEN"**
+   - Ensure you've set the `ROASTER_SLACK_TOKEN` repository variable
    - Verify the token starts with `xoxb-`
 
-2. **"Missing SLACK_CHANNEL_ID"**
-   - Ensure you've set the `SLACK_CHANNEL_ID` repository variable
+2. **"Missing ROASTER_SLACK_CHANNEL_ID"**
+   - Ensure you've set the `ROASTER_SLACK_CHANNEL_ID` repository variable
    - Verify the channel ID format (usually starts with `C`)
 
 3. **"Bot not in channel" error**
@@ -118,7 +118,7 @@ When posting to Slack, the bot will create rich message blocks including:
 
 ## Security Considerations
 
-- Keep your `SLACK_TOKEN` secret and never commit it to your repository
+- Keep your `ROASTER_SLACK_TOKEN` secret and never commit it to your repository
 - Use GitHub's encrypted secrets/variables feature
 - Consider using a dedicated bot account rather than a personal token
 - Regularly rotate your Slack tokens

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,17 +202,17 @@ export default function appFn(app: Probot) {
           title: "Roaster Bot Installation Instructions",
           body: `To configure the bot, you need to set up the following repository variables:
 
-## Required Variables:
-1. \`OPENAI_API_KEY\` - Your OpenAI API key
+  ## Required Variables:
+1. \`ROASTER_OPENAI_API_KEY\` - Your OpenAI API key
 
-## Optional Variables:
+  ## Optional Variables:
 2. \`ROASTER_UNCENSORED\` - Set to "true" to enable uncensored mode (defaults to "false")
-3. \`GITHUB_CHANNEL_ENABLED\` - Set to "true" to enable GitHub comments (defaults to "true")
-4. \`SLACK_CHANNEL_ENABLED\` - Set to "true" to enable Slack integration (defaults to "false")
+3. \`ROASTER_GITHUB_CHANNEL_ENABLED\` - Set to "true" to enable GitHub comments (defaults to "true")
+4. \`ROASTER_SLACK_CHANNEL_ENABLED\` - Set to "true" to enable Slack integration (defaults to "false")
 
-## Slack Configuration (if enabled):
-5. \`SLACK_TOKEN\` - Your Slack bot token (starts with "xoxb-")
-6. \`SLACK_CHANNEL_ID\` - The Slack channel ID where roasts will be posted
+  ## Slack Configuration (if enabled):
+5. \`ROASTER_SLACK_TOKEN\` - Your Slack bot token (starts with "xoxb-")
+6. \`ROASTER_SLACK_CHANNEL_ID\` - The Slack channel ID where roasts will be posted
 
 ## Notes:
 - Both GitHub and Slack channels can be enabled simultaneously


### PR DESCRIPTION
## Summary
- update config instructions with ROASTER_ prefixes
- fix Slack setup guide to use the same names

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798537ba50832da9bb3d57022bd137