### PR TITLE
Fix configuration variable mismatch

### DIFF
--- a/SLACK_SETUP.md
+++ b/SLACK_SETUP.md
@@ -60,7 +60,7 @@ Add the following repository variables:
 - `GITHUB_CHANNEL_ENABLED` = `true` (default: true)
 
 ### Other Configuration:
-- `OPENAI_API_KEY` = `sk-your-openai-api-key` (required)
+- `ROASTER_OPENAI_API_KEY` = `sk-your-openai-api-key` (required)
 - `ROASTER_UNCENSORED` = `false` (default: false)
 
 ## Step 6: Test Your Setup

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -79,7 +79,7 @@ export class ConfigLoader {
   private validateConfig(config: AppConfig): void {
     // Validate OpenAI API key
     if (!config.openai.apiKey) {
-      throw new Error("OPENAI_API_KEY is required");
+      throw new Error("ROASTER_OPENAI_API_KEY is required");
     }
 
     // Validate at least one channel is enabled

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ export default function appFn(app: Probot) {
           body: `To configure the bot, you need to set up the following repository variables:
 
 ## Required Variables:
-1. \`OPENAI_API_KEY\` - Your OpenAI API key
+1. \`ROASTER_OPENAI_API_KEY\` - Your OpenAI API key
 
 ## Optional Variables:
 2. \`ROASTER_UNCENSORED\` - Set to "true" to enable uncensored mode (defaults to "false")


### PR DESCRIPTION
## Summary
- correct variable name in `ConfigLoader` to `ROASTER_OPENAI_API_KEY`
- update docs and installation issue text accordingly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687984ac3b44832d9818312e80638515